### PR TITLE
Discover org repos; search by owner and filter the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ For each monitored repository you get:
   ![CI race to green](docs/screenshots/ci-race.png)
 
 - **Dashboard overview** — commits-per-repo bars, sortable repo cards with
-  daily activity chips, live sync status, and latest CI state; new repos are
-  added in place with typeahead autocomplete.
+  daily activity chips, live sync status, and latest CI state; a filter box
+  narrows the cards, and new repos are added in place with typeahead
+  autocomplete over every repo you can reach (your account and your orgs).
 
   ![Dashboard](docs/screenshots/dashboard.png)
 

--- a/app/controllers/suggestions_controller.rb
+++ b/app/controllers/suggestions_controller.rb
@@ -6,9 +6,8 @@ class SuggestionsController < ApplicationController
     query = params[:q].to_s.strip.downcase
     monitored = Repository.pluck(:owner, :name).map { |owner, name| "#{owner}/#{name}".downcase }.to_set
 
-    suggestions = user_repositories
-      .reject { |repo| monitored.include?(repo[:full_name].downcase) }
-      .select { |repo| matches?(repo, query) }
+    candidates = user_repositories.reject { |repo| monitored.include?(repo[:full_name].downcase) }
+    suggestions = rank(candidates.select { |repo| matches?(repo, query) }, query)
       .first(LIMIT)
       .map { |repo| repo.merge(display_name: display_name(repo)) }
 
@@ -19,13 +18,35 @@ class SuggestionsController < ApplicationController
 
   private
 
-  # Matches on the repo name segment — the owner prefix would match every
-  # repo (e.g. "ai" is a substring of "akitaonrails").
+  # A repo matches when the query is a substring of its name ("eop"), or a
+  # prefix of its owner ("blue3" → BLUE3-ISP's repos). Owner is matched as a
+  # prefix, not a substring, so a common owner ("akitaonrails") doesn't match
+  # every stray query ("ai"). "owner/name" narrows both segments at once.
   def matches?(repo, query)
     return true if query.blank?
 
     owner, name = repo[:full_name].downcase.split("/", 2)
-    name.include?(query.delete_prefix("#{owner}/"))
+    if query.include?("/")
+      query_owner, query_name = query.split("/", 2)
+      owner.start_with?(query_owner) && name.to_s.include?(query_name)
+    else
+      name.to_s.include?(query) || owner.start_with?(query)
+    end
+  end
+
+  # Rank repos matching on the name segment above those matching only on the
+  # owner, so typing a repo name surfaces it even when an org shares the text.
+  # partition is stable, so each group keeps the pushed-recency order.
+  def rank(repos, query)
+    return repos if query.blank?
+
+    name_query = query.split("/", 2).last
+    name_matches, owner_only = repos.partition { |repo| repo_name(repo).include?(name_query) }
+    name_matches + owner_only
+  end
+
+  def repo_name(repo)
+    repo[:full_name].downcase.split("/", 2).last.to_s
   end
 
   def display_name(repo)

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 // Typeahead for the add-repository field, backed by /suggestions
-// (the GitHub repos of the configured owner, minus already-monitored ones).
+// (the GitHub repos you can reach — incl. your orgs — minus monitored ones).
 export default class extends Controller {
   static targets = ["input", "list"]
   static values = { url: String }

--- a/app/javascript/controllers/repo_filter_controller.js
+++ b/app/javascript/controllers/repo_filter_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Client-side filter for the monitored-repo cards: hides any card whose
+// "owner/name" (data-repo-name) doesn't contain the typed text. Every card is
+// already on the page, so this never hits the server.
+export default class extends Controller {
+  static targets = ["field", "item", "empty"]
+
+  filter() {
+    const query = this.fieldTarget.value.trim().toLowerCase()
+    let visible = 0
+
+    this.itemTargets.forEach((item) => {
+      const match = query === "" || item.dataset.repoName.includes(query)
+      item.classList.toggle("hidden", !match)
+      if (match) visible += 1
+    })
+
+    if (this.hasEmptyTarget) this.emptyTarget.classList.toggle("hidden", visible > 0)
+  }
+}

--- a/app/services/github/client.rb
+++ b/app/services/github/client.rb
@@ -11,6 +11,10 @@ module Github
 
     API_HOST = "api.github.com".freeze
     PAGE_SIZE = 100
+    # Which repos /user/repos returns for the add-repo autocomplete: everything
+    # the token can reach — personally owned, collaborations, and organization
+    # membership — so repos in your orgs are discoverable, not just owned ones.
+    REPO_AFFILIATION = "owner,collaborator,organization_member".freeze
 
     HISTORY_QUERY = <<~GRAPHQL.freeze
       query($owner: String!, $name: String!, $since: GitTimestamp, $cursor: String, $pageSize: Int!) {
@@ -78,14 +82,14 @@ module Github
       rest_get("/user")["login"]
     end
 
-    # Repos owned by the token's user (public and private), most recently
-    # pushed first. Used for the add-repository autocomplete.
+    # Repos the token's user can reach (see REPO_AFFILIATION; public and
+    # private), most recently pushed first. Used for the add-repo autocomplete.
     def user_repositories(max_repos: 300)
       repos = []
       page = 1
 
       while repos.size < max_repos
-        body = rest_get("/user/repos?per_page=#{PAGE_SIZE}&page=#{page}&affiliation=owner&sort=pushed")
+        body = rest_get("/user/repos?per_page=#{PAGE_SIZE}&page=#{page}&affiliation=#{REPO_AFFILIATION}&sort=pushed")
         break if body.empty?
 
         repos.concat(body.map do |repo|

--- a/app/views/dashboard/_content.html.erb
+++ b/app/views/dashboard/_content.html.erb
@@ -1,4 +1,4 @@
-<div id="dashboard-content">
+<div id="dashboard-content" data-controller="repo-filter">
   <% if repositories.empty? %>
     <p class="mt-16 text-neutral-500 text-center">
       No repositories yet. Add one above (for example <span class="text-neutral-300">akitaonrails/ai-memory</span>)
@@ -32,29 +32,41 @@
       <% end %>
     </section>
 
-    <div class="flex items-center justify-end gap-1 mt-10 text-xs">
-      <span class="text-neutral-500 uppercase tracking-widest mr-2">sort</span>
-      <% active_key, active_direction = sort.split("_") %>
-      <% { "updated" => "modified", "name" => "name", "created" => "created" }.each do |key, label| %>
-        <% is_active = active_key == key %>
-        <% next_direction =
-             if is_active
-               active_direction == "desc" ? "asc" : "desc"
-             else
-               key == "name" ? "asc" : "desc"
-             end %>
-        <%= link_to "#{label}#{is_active ? (active_direction == "desc" ? " ↓" : " ↑") : ""}",
-              root_path(sort: "#{key}_#{next_direction}"),
-              class: "border rounded px-2.5 py-1 #{is_active ?
-                'border-fuchsia-700 bg-fuchsia-950/60 text-fuchsia-300' :
-                'border-neutral-700 text-neutral-400 hover:bg-neutral-800'}" %>
-      <% end %>
+    <div class="flex items-center justify-between gap-3 mt-10 text-xs flex-wrap">
+      <input type="search" placeholder="filter repos…" autocomplete="off" aria-label="filter repositories"
+             data-repo-filter-target="field" data-action="input->repo-filter#filter"
+             class="bg-neutral-900 border border-neutral-700 rounded px-3 py-1.5 w-48
+                    text-neutral-200 placeholder-neutral-600 focus:outline-none focus:border-fuchsia-500">
+      <div class="flex items-center gap-1">
+        <span class="text-neutral-500 uppercase tracking-widest mr-2">sort</span>
+        <% active_key, active_direction = sort.split("_") %>
+        <% { "updated" => "modified", "name" => "name", "created" => "created" }.each do |key, label| %>
+          <% is_active = active_key == key %>
+          <% next_direction =
+               if is_active
+                 active_direction == "desc" ? "asc" : "desc"
+               else
+                 key == "name" ? "asc" : "desc"
+               end %>
+          <%= link_to "#{label}#{is_active ? (active_direction == "desc" ? " ↓" : " ↑") : ""}",
+                root_path(sort: "#{key}_#{next_direction}"),
+                class: "border rounded px-2.5 py-1 #{is_active ?
+                  'border-fuchsia-700 bg-fuchsia-950/60 text-fuchsia-300' :
+                  'border-neutral-700 text-neutral-400 hover:bg-neutral-800'}" %>
+        <% end %>
+      </div>
     </div>
 
     <section class="mt-3 grid gap-4 sm:grid-cols-2">
       <% repositories.each do |repository| %>
-        <%= render "dashboard/card", repository: repository, stats: overview.for(repository), chip_days: overview.chip_dates.size %>
+        <div data-repo-filter-target="item" data-repo-name="<%= repository.full_name.downcase %>">
+          <%= render "dashboard/card", repository: repository, stats: overview.for(repository), chip_days: overview.chip_dates.size %>
+        </div>
       <% end %>
     </section>
+
+    <p data-repo-filter-target="empty" class="hidden mt-8 text-center text-neutral-600 text-sm">
+      No repositories match your filter.
+    </p>
   <% end %>
 </div>

--- a/test/controllers/dashboard_controller_test.rb
+++ b/test/controllers/dashboard_controller_test.rb
@@ -68,6 +68,15 @@ class DashboardControllerTest < ActionDispatch::IntegrationTest
     assert_no_match(/\(akitaonrails\)/, response.body)
   end
 
+  test "index renders a client-side filter over the repo cards" do
+    get root_url
+
+    assert_select "[data-controller='repo-filter']"
+    assert_select "input[data-repo-filter-target='field']"
+    assert_select "[data-repo-filter-target='item']", count: 2
+    assert_match 'data-repo-name="akitaonrails/ai-memory"', response.body
+  end
+
   test "index renders empty state without repositories" do
     Repository.destroy_all
     get root_url

--- a/test/controllers/suggestions_controller_test.rb
+++ b/test/controllers/suggestions_controller_test.rb
@@ -45,6 +45,34 @@ class SuggestionsControllerTest < ActionDispatch::IntegrationTest
     ENV.delete("GITHUB_OWNER")
   end
 
+  test "index finds org repos by owner, ranking name matches first" do
+    stub_request(:get, %r{https://api\.github\.com/user/repos})
+      .to_return(status: 200, headers: github_headers, body: [
+        { full_name: "BLUE3-ISP/eop", description: "org repo", private: true },
+        { full_name: "samirhvbr/blue3-notes", description: "personal", private: false }
+      ].to_json)
+
+    get suggestions_url(q: "blue3")
+
+    names = response.parsed_body.map { |repo| repo["full_name"] }
+    assert_includes names, "BLUE3-ISP/eop"          # matched on the owner
+    assert_includes names, "samirhvbr/blue3-notes"  # matched on the name
+    assert_equal "samirhvbr/blue3-notes", names.first # name match ranks above owner-only
+  end
+
+  test "index still matches on the repo name segment" do
+    stub_request(:get, %r{https://api\.github\.com/user/repos})
+      .to_return(status: 200, headers: github_headers, body: [
+        { full_name: "BLUE3-ISP/eop", description: nil, private: true },
+        { full_name: "samirhvbr/other", description: nil, private: false }
+      ].to_json)
+
+    get suggestions_url(q: "eop")
+
+    names = response.parsed_body.map { |repo| repo["full_name"] }
+    assert_equal [ "BLUE3-ISP/eop" ], names
+  end
+
   test "index returns empty list when GitHub errors" do
     stub_request(:get, %r{https://api\.github\.com/user/repos}).to_return(status: 500)
 

--- a/test/services/github/client_test.rb
+++ b/test/services/github/client_test.rb
@@ -76,18 +76,19 @@ module Github
       assert_equal Time.utc(2026, 7, 1, 12, 5), runs.first[:run_started_at]
     end
 
-    test "user_repositories maps owned repos" do
+    test "user_repositories spans owned, collaborator and org repos" do
       stub_request(:get, %r{https://api\.github\.com/user/repos})
-        .with(query: hash_including("affiliation" => "owner"))
+        .with(query: hash_including("affiliation" => "owner,collaborator,organization_member"))
         .to_return(status: 200, headers: github_headers, body: [
           { full_name: "akitaonrails/ai-memory", description: "memory", private: false },
-          { full_name: "akitaonrails/secret", description: nil, private: true }
+          { full_name: "BLUE3-ISP/secret", description: nil, private: true }
         ].to_json)
 
       repos = @client.user_repositories
 
       assert_equal 2, repos.size
       assert_equal "akitaonrails/ai-memory", repos.first[:full_name]
+      assert_equal "BLUE3-ISP/secret", repos.last[:full_name]
       assert repos.last[:private]
     end
 


### PR DESCRIPTION
## What & why

The add-repository autocomplete only offered repositories the token owns
personally (`affiliation=owner`), so repositories in organizations the user
belongs to never showed up in the typeahead — the dashboard looked like it only
knew the configured owner, even though the token can read those repos. There was
also no way to search across owners, or to find a repo among many
already-monitored cards.

## Changes

- **Discover org repos** — `Github::Client#user_repositories` now requests
  `affiliation=owner,collaborator,organization_member`, so organization and
  collaboration repos are discoverable. (Typing `owner/name` by hand already
  worked; this fixes discovery.)
- **Search by owner or name** — `SuggestionsController` matches the query as a
  substring of the repo name OR a prefix of the owner (`blue3` → that org's
  repos), ranking name matches above owner-only ones. Owner is matched as a
  prefix (not a substring) so a common owner no longer matches every stray query
  (`ai` → `akitaonrails`). `owner/name` narrows both segments.
- **Dashboard filter** — a client-side filter over the repo cards (new
  `repo_filter` Stimulus controller) to find a repo among many.

## Tests

Updated the client, suggestions, and dashboard tests, and added coverage for
org-owner matching and name-vs-owner ranking.
